### PR TITLE
Update to code for integration with frontend

### DIFF
--- a/backend/des/DES.py
+++ b/backend/des/DES.py
@@ -35,6 +35,8 @@ def arrivals_to_rate(arrivals : int):
     Returns:
         float: The calculated arrival rate per hour.
     """
+    if arrivals == 0:
+        return 0
     return 1 / (arrivals / 60)
 
 def get_arrival_interval(minutes : int, month=None, lambdas=None):

--- a/backend/des/DES.py
+++ b/backend/des/DES.py
@@ -264,6 +264,10 @@ def run_nsim(cap_dict : dict, n=100, month=None, lambdas=None, overall_stats={})
         print_stats(stats)
         print(f"--- Simulation {i + 1} completed in {time.time() - start:.2f} seconds ---\n")
 
+    ## Round off overall output
+    for key, val in overall_stats.items():
+        overall_stats[key] = [int(x) for x in val]
+        
     duration = (time.time() - init_time) / 60 # convert to minutes
     print_stats(overall_stats)
     print(f"--- Total running time {duration:.2f} minutes ---")

--- a/backend/des/DES.py
+++ b/backend/des/DES.py
@@ -20,7 +20,7 @@ def get_lambda(month : int, hour : int):
     Returns:
         float: The number of arrivala (lambda).
     """
-    return params.LAMBDAS[(month, hour)]
+    return np.random.poisson(params.LAMBDAS[(month, hour)])
 
 def arrivals_to_rate(arrivals : int):
     """
@@ -45,7 +45,7 @@ def get_arrival_interval(month : int, minutes : int):
     Returns:
         float: The calculated time interval between arrivals (in minutes).
     """
-    return arrivals_to_rate(np.random.poisson(get_lambda(month, params.minutes_to_hours(minutes))))
+    return arrivals_to_rate(get_lambda(month, params.minutes_to_hours(minutes)))
 
 def custom_choice(items : list, prob : list):
     """

--- a/backend/des/DES.py
+++ b/backend/des/DES.py
@@ -5,7 +5,6 @@ from carpark import CarPark
 from car import Car
 import time
 import params
-import datetime
 
 ## time unit : minutes
 
@@ -240,13 +239,11 @@ def sim(cap=params.CP_CAPACITY, cp_prob=params.CP_PROB, car_prob=params.CAR_PROB
     stats = stats_summary(carparks)
     return stats
 
-if __name__ == "__main__":
-    
+def run_nsim(n=100, cap=params.CP_CAPACITY, cp_prob=params.CP_PROB, car_prob=params.CAR_PROB, t=params.SIM_TIME, overall_stats={}):
     init_time = time.time()
-    overall_stats = {}
-    
+
     ## Run simulation for n times
-    for i in range(params.NSIM):
+    for i in range(n):
         ## Track simulation time
         start = time.time() 
 
@@ -261,3 +258,7 @@ if __name__ == "__main__":
     duration = (time.time() - init_time) / 60 # convert to minutes
     print_stats(overall_stats)
     print(f"--- Total running time {duration:.2f} minutes ---")
+    return overall_stats
+
+if __name__ == "__main__":
+    overall_stats = run_nsim()

--- a/backend/des/DES.py
+++ b/backend/des/DES.py
@@ -1,3 +1,4 @@
+from matplotlib.style import available
 import numpy as np
 import simpy
 from simpy import Environment
@@ -214,7 +215,7 @@ def print_stats(d : dict):
         print(f"{cp:<5}: {stat}")
     return
 
-def sim(cap=params.CP_CAPACITY, cp_prob=params.CP_PROB, car_prob=params.CAR_PROB, t=params.SIM_TIME, month=None, lambdas=None):
+def sim(cap=params.CP_CAPACITY, t=params.SIM_TIME, month=None, lambdas=None):
     """
     Run a car park simulation.
 
@@ -227,6 +228,9 @@ def sim(cap=params.CP_CAPACITY, cp_prob=params.CP_PROB, car_prob=params.CAR_PROB
     Returns:
         dict: A dictionary containing summary statistics for each car park.
     """
+    available_cp = list(cap.keys())
+    cp_prob = params.get_carpark_prob(available_cp)
+    car_prob = params.get_parking_type_prop(available_cp)
 
     ## init Environment
     campus = Environment()
@@ -242,7 +246,7 @@ def sim(cap=params.CP_CAPACITY, cp_prob=params.CP_PROB, car_prob=params.CAR_PROB
     stats = stats_summary(carparks)
     return stats
 
-def run_nsim(n=100, month=None, lambdas=None, overall_stats={}):
+def run_nsim(cap_dict : dict, n=100, month=None, lambdas=None, overall_stats={}):
     init_time = time.time()
 
     ## Run simulation for n times
@@ -251,7 +255,7 @@ def run_nsim(n=100, month=None, lambdas=None, overall_stats={}):
         start = time.time() 
 
         ## Run simulation
-        stats = sim(month=month, lambdas=lambdas)
+        stats = sim(cap_dict, month=month, lambdas=lambdas)
 
         ## Simulation output
         overall_stats = stats_mean(overall_stats, stats)
@@ -265,4 +269,4 @@ def run_nsim(n=100, month=None, lambdas=None, overall_stats={}):
 
 if __name__ == "__main__":
     n = 1 if len(sys.argv) == 1 else int(sys.argv[1])
-    overall_stats = run_nsim(n=n)
+    overall_stats = run_nsim(params.CP_CAPACITY, n=n)

--- a/backend/des/DES.py
+++ b/backend/des/DES.py
@@ -238,6 +238,9 @@ def sim(cap=params.CP_CAPACITY, t=params.SIM_TIME, month=None, lambdas=None):
     Returns:
         dict: A dictionary containing summary statistics for each car park.
     """
+    if cap == {} or not any(lambdas):
+        return {}
+
     available_cp = list(cap.keys())
     cp_prob = params.get_carpark_prob(available_cp)
     car_prob = params.get_parking_type_prop(available_cp)

--- a/backend/des/DES.py
+++ b/backend/des/DES.py
@@ -5,6 +5,7 @@ from carpark import CarPark
 from car import Car
 import time
 import params
+import sys
 
 ## time unit : minutes
 
@@ -125,14 +126,14 @@ def car_generator(env : simpy.Environment, carparks : list, cp_prob_dict : dict,
         ## Car arrive at campus
         car = Car(car_id, tpe)
         time = get_arrival_interval(month, env.now) # time before next car arrive
-        assert time >= 0
+        # assert time >= 0
         yield env.timeout(time)
         # car = car_arrival(env, car_id, tpe)
 
         ## Choose carpark
         cp_dict = cp_prob_dict[tpe]
         cp_prob = [cp_dict[cp.get_name()] for cp in carparks]
-        assert sum(cp_prob) == 1.0
+        # assert sum(cp_prob) == 1.0
 
         ## TODO: car should only be able to choose from cp with given parking type
         
@@ -239,7 +240,7 @@ def sim(cap=params.CP_CAPACITY, cp_prob=params.CP_PROB, car_prob=params.CAR_PROB
     stats = stats_summary(carparks)
     return stats
 
-def run_nsim(n=100, cap=params.CP_CAPACITY, cp_prob=params.CP_PROB, car_prob=params.CAR_PROB, t=params.SIM_TIME, overall_stats={}):
+def run_nsim(n=100, overall_stats={}):
     init_time = time.time()
 
     ## Run simulation for n times
@@ -261,4 +262,5 @@ def run_nsim(n=100, cap=params.CP_CAPACITY, cp_prob=params.CP_PROB, car_prob=par
     return overall_stats
 
 if __name__ == "__main__":
-    overall_stats = run_nsim()
+    n = 1 if len(sys.argv) == 1 else int(sys.argv[1])
+    overall_stats = run_nsim(n=n)

--- a/backend/des/car.py
+++ b/backend/des/car.py
@@ -1,7 +1,7 @@
 import numpy as np
-from params import get_parking_duration_stats
+from params import CP_LIST, get_parking_duration_stats
 
-park_du = get_parking_duration_stats()
+park_du = get_parking_duration_stats(CP_LIST)
 class Car:
     """
     Represents a car in a parking simulation.

--- a/backend/des/carpark.py
+++ b/backend/des/carpark.py
@@ -206,7 +206,8 @@ class CarPark:
                 self.totalRed, 
                 self.whiteRejected, 
                 self.redRejected, 
-                self.occupied(ratio=True)]
+                self.whiteCars, 
+                self.redCars]
 
     def park_car(self, car : Car):
         """

--- a/backend/des/carpark.py
+++ b/backend/des/carpark.py
@@ -69,6 +69,14 @@ class CarPark:
         self.whiteRejected = 0
         self.redRejected = 0 
 
+        ## Track metrics over 24 hours
+        self.whiteCars24 = []
+        self.redCars24 = []
+        self.whiteTotal24 = []
+        self.redTotal24 = []
+        self.whiteRejected24 = []
+        self.redRejected24 = []
+
         self.spots = Resource(env, capacity=self.capacity)
 
     def get_name(self):
@@ -189,6 +197,14 @@ class CarPark:
         else: 
             self.whiteRejected += 1
             return "white"
+        
+    def record(self):
+        self.whiteCars24.append(self.whiteCars)
+        self.redCars24.append(self.redCars)
+        self.whiteTotal24.append(self.totalWhite)
+        self.redTotal24.append(self.totalRed)
+        self.whiteRejected24.append(self.whiteRejected)
+        self.redRejected24.append(self.redRejected)
 
     def stats(self):
         """
@@ -202,12 +218,12 @@ class CarPark:
                 - Total number of red cars turned away (rejected).
                 - The current occupancy ratio of the car park.
         """
-        return [self.totalWhite, 
-                self.totalRed, 
-                self.whiteRejected, 
-                self.redRejected, 
-                self.whiteCars, 
-                self.redCars]
+        return [self.whiteTotal24, 
+                self.redTotal24, 
+                self.whiteRejected24, 
+                self.redRejected24, 
+                self.whiteCars24, 
+                self.redCars24]
 
     def park_car(self, car : Car):
         """

--- a/backend/des/params.py
+++ b/backend/des/params.py
@@ -188,7 +188,6 @@ def get_parking_duration_stats(data=cp_data):
 
 ## TODO: take input from user / database
 SIM_TIME = 24 * 60 # in minutes
-NSIM = 1
 CP_CAPACITY = get_carpark_capacity()
 CP_PROB = get_carpark_prob()
 CAR_PROB = get_parking_type_prop()

--- a/backend/des/params.py
+++ b/backend/des/params.py
@@ -40,7 +40,11 @@ def get_day_arrival_rate(day : str, data=cp_data):
     users = filtered_data[["year", "enter_hour"]]
     users = users.groupby(["year", "enter_hour"]).size().reset_index()
     users = users.groupby(["enter_hour"]).agg({0 : 'mean'})
-    return users.to_dict()[0]
+    users = users.to_dict()[0] 
+    
+    for h in range(24):
+        users[h] = users.get(h, 0)
+    return users
 
 
 def minutes_to_hours(minutes : int):

--- a/backend/des/params.py
+++ b/backend/des/params.py
@@ -157,12 +157,14 @@ def get_arrival_rates(cp : list, data=cp_data):
     data = filter_cp(data.copy(), cp)
     data['enter_dt'] = pd.to_datetime(data['enter_dt'])
     data['enter_hour'] = data['enter_dt'].dt.hour
+    data['day'] = data['enter_dt'].dt.day
     data['month'] = data['enter_dt'].dt.month
     data['year'] = data['enter_dt'].dt.year
 
-    users = data[["month", "year", "enter_hour"]]
-    users = users.groupby(["month", "year", "enter_hour"]).size().reset_index()
+    users = data[["day", "month", "year", "enter_hour"]]
+    users = users.groupby(["day", "month", "year", "enter_hour"]).size().reset_index()
     users = users.groupby(["month", "enter_hour"]).agg({0 : 'mean'})
+    users[0] = users[0].apply(lambda x: int(x))
     return users.to_dict()[0]
 
 def get_parking_duration_stats(cp : list, data=cp_data):

--- a/backend/des/params.py
+++ b/backend/des/params.py
@@ -7,7 +7,6 @@ DATA_FPATH = "../../data/Cleaned/all_carparks_cleaned.csv"
 capacity_data = pd.read_excel(CAP_FPATH)
 cp_data = pd.read_csv(DATA_FPATH, low_memory=False)
 
-## TODO: filter based on carparks with non-0 capacity
 def filter_cp(data : pd.DataFrame, cp : list):
     data = data.copy()
     data["carpark"] = data["carpark"].str.lower()
@@ -24,7 +23,7 @@ def get_month_arrival_rate(month : int):
     Returns:
         dict: A dictionary where key is hour (0-23) and values are the mean arrivals for each corresponding time interval.
     """
-    return {h : val for (m, h), val in get_arrival_rates().items() if m == month}
+    return {h : val for (m, h), val in get_arrival_rates(CP_LIST).items() if m == month}
 
 def get_day_arrival_rate(day : str, data=cp_data):
     """

--- a/backend/des/params.py
+++ b/backend/des/params.py
@@ -8,6 +8,11 @@ capacity_data = pd.read_excel(CAP_FPATH)
 cp_data = pd.read_csv(DATA_FPATH, low_memory=False)
 
 ## TODO: filter based on carparks with non-0 capacity
+def filter_cp(data : pd.DataFrame, cp : list):
+    data = data.copy()
+    data["carpark"] = data["carpark"].str.lower()
+    data = data[data["carpark"].isin(cp)]
+    return data
 
 def get_month_arrival_rate(month : int):
     """
@@ -32,6 +37,7 @@ def get_day_arrival_rate(day : str, data=cp_data):
         dict: A dictionary where key is hour (0-23) and values are the mean arrivals for each corresponding time interval.
     """
     day = pd.to_datetime(day)
+    data = data.copy()
     data['enter_dt'] = pd.to_datetime(data['enter_dt'])
     filtered_data = data[data['enter_dt'].dt.date == day.date()]
     filtered_data['enter_hour'] = filtered_data['enter_dt'].dt.hour
@@ -59,7 +65,7 @@ def minutes_to_hours(minutes : int):
     """
     return int(minutes / 60)
 
-def get_carpark_capacity(data=capacity_data):
+def get_carpark_capacity(cp : list, data=capacity_data):
     """
     Get the car park capacity (number of white and red lots) for each car park.
 
@@ -70,15 +76,18 @@ def get_carpark_capacity(data=capacity_data):
         dict: A dictionary where keys are car park names (in lowercase), and values are tuples containing the number of white and red lots.
     """
     d = {}
+    data = data.copy()
+    data["CP"] = data["CP"].apply(lambda x: f"cp{x}")
+    data = data[data["CP"].isin(cp)]
     data = data[["CP", "White", "Red"]].to_dict(orient="list")
 
     for i in range(len(data["CP"])):
-        cp = f"cp{data['CP'][i]}"
+        cp = data['CP'][i]
         d[cp] = (data["White"][i], data["Red"][i])
     
     return d
 
-def get_carpark_prob(data=cp_data):
+def get_carpark_prob(cp : list, data=cp_data):
     """
     Get the probability of car park utilization by user type for each car park.
 
@@ -90,6 +99,7 @@ def get_carpark_prob(data=cp_data):
              The values are the probabilities of car park utilization by that user type for the corresponding car park.
     """
     d = {}
+    data = filter_cp(data.copy(), cp)
 
     ## Calculate proportion of user type for each carpark
     cap = data.groupby(["carpark", "type"])["IU"].count().reset_index()
@@ -114,7 +124,7 @@ def get_carpark_prob(data=cp_data):
         
     return d
 
-def get_parking_type_prop(data=cp_data):
+def get_parking_type_prop(cp : list, data=cp_data):
     """
     Get the proportion of each parking type in the dataset.
 
@@ -124,6 +134,7 @@ def get_parking_type_prop(data=cp_data):
     Returns:
         dict: A dictionary where keys are parking types, and values are the proportions of each type in the dataset.
     """
+    data = filter_cp(data, cp)
     ## Calculate proportion of parking types
     users = data.groupby("type").agg({"IU" : 'count'})
     users["total"] = users["IU"].sum()
@@ -134,7 +145,7 @@ def get_parking_type_prop(data=cp_data):
 
     return users
 
-def get_arrival_rates(data=cp_data):
+def get_arrival_rates(cp : list, data=cp_data):
     """
     Calculate the mean arrival (lambda) of users for each month and hour.
 
@@ -144,6 +155,7 @@ def get_arrival_rates(data=cp_data):
     Returns:
         dict: A dictionary where keys are tuples of (month, hour) and values are the mean arrivals for each corresponding time interval.
     """
+    data = filter_cp(data.copy(), cp)
     data['enter_dt'] = pd.to_datetime(data['enter_dt'])
     data['enter_hour'] = data['enter_dt'].dt.hour
     data['month'] = data['enter_dt'].dt.month
@@ -154,7 +166,7 @@ def get_arrival_rates(data=cp_data):
     users = users.groupby(["month", "enter_hour"]).agg({0 : 'mean'})
     return users.to_dict()[0]
 
-def get_parking_duration_stats(data=cp_data):
+def get_parking_duration_stats(cp : list, data=cp_data):
     """
     Get parking duration statistics (median and standard deviation) for each car park and user type.
 
@@ -164,6 +176,7 @@ def get_parking_duration_stats(data=cp_data):
     Returns:
         dict: A dictionary where keys are tuples of (car park name, user type), and values are tuples containing the median and standard deviation of parking durations.
     """
+    data = filter_cp(data.copy(), cp)
     data['enter_dt'] = pd.to_datetime(data['enter_dt'])
     data['hour'] = data['enter_dt'].dt.hour
 
@@ -187,9 +200,10 @@ def get_parking_duration_stats(data=cp_data):
     return du
 
 ## TODO: take input from user / database
+CP_LIST = ["cp3", "cp3a", "cp4", "cp5", "cp5b", "cp6b"]
 SIM_TIME = 24 * 60 # in minutes
-CP_CAPACITY = get_carpark_capacity()
-CP_PROB = get_carpark_prob()
-CAR_PROB = get_parking_type_prop()
-LAMBDAS = get_arrival_rates()
+CP_CAPACITY = get_carpark_capacity(CP_LIST)
+CP_PROB = get_carpark_prob(CP_LIST)
+CAR_PROB = get_parking_type_prop(CP_LIST)
+LAMBDAS = get_arrival_rates(CP_LIST)
 MONTH = datetime.date.today().month


### PR DESCRIPTION
Updated code to take in input and output in the required format as per frontend request

Input
1. carpark arrivalrates - list of 24 values [100,0,.....,6000,..]
2. lot dicts { 'cp3':(white lots cap, red lots cap)...}

Output
1. {'cp3':[1,2,3,4,5,6]}

- Total number of white cars entered.
- Total number of red cars entered.
- Total number of white cars turned away (rejected).
- Total number of red cars turned away (rejected).
- White lots occupied end of sim
- Red lots occupied end of sim

@hoofangyu please test if it can be integrated.